### PR TITLE
CLI: Override 'wp glotpress translation-set import' command to support 'disable-propagating'

### DIFF
--- a/gp-translation-propagation.php
+++ b/gp-translation-propagation.php
@@ -52,6 +52,8 @@ function gptp_init() {
  */
 function gptp_register_cli_commands() {
 	require_once __DIR__ . '/inc/cli/import-originals.php';
+	require_once __DIR__ . '/inc/cli/translation-set.php';
 
 	WP_CLI::add_command( 'glotpress import-originals', 'GP_CLI_Import_Originals_With_Propagation' );
+	WP_CLI::add_command( 'glotpress translation-set', 'GP_CLI_Translation_Set_With_Propagation' );
 }

--- a/inc/cli/translation-set.php
+++ b/inc/cli/translation-set.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Translation Propagation: GP_CLI_Translation_Set_With_Propagation class
+ *
+ * @package GlotPress
+ * @subpackage Translation_Propagation_CLI
+ * @since 1.0.0
+ */
+
+/**
+ * Core class used to override the default import command.
+ *
+ * @since 1.0.0
+ */
+class GP_CLI_Translation_Set_With_Propagation extends GP_CLI_Translation_Set {
+
+	/**
+	 * Import a file into the translation set
+	 *
+	 * ## OPTIONS
+	 *
+	 * <project>
+	 * : Project path
+	 *
+	 * <locale>
+	 * : Locale to export
+	 *
+	 * <file>
+	 * : File to import
+	 *
+	 * [--set=<set>]
+	 * : Translation set slug; default is "default"
+	 *
+	 * [--disable-propagating]
+	 * : If set, propagation will be disabled.
+	 *
+	 * @param array $args       Arguments passed to the command.
+	 * @param array $assoc_args Parameters passed to the command.
+	 */
+	public function import( $args, $assoc_args ) {
+		$disable_propagating = isset( $assoc_args['disable-propagating'] );
+		if ( $disable_propagating ) {
+			add_filter( 'gp_enable_propagate_translations_across_projects', '__return_false' );
+		}
+
+		parent::import( $args, $assoc_args );
+
+		if ( $disable_propagating ) {
+			remove_filter( 'gp_enable_propagate_translations_across_projects', '__return_false' );
+		}
+	}
+}


### PR DESCRIPTION
Fixes #5.
